### PR TITLE
Fix text in segmented control would not show up if call setItems: twice

### DIFF
--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -711,6 +711,10 @@
     for (int i = 0; i < self.numberOfSegments; i++) {
         [self addButtonForSegment:i];
     }
+
+    if (self.window) {
+        [self configureSegments];
+    }
 }
 
 - (void)addButtonForSegment:(NSUInteger)segment


### PR DESCRIPTION
How to reproduce:

1. Make a segmented control with some items
2. Call `segmentedControl.items = @["abc", "def"];` some time later
3. Text in segmented control would not show up