### PR TITLE
fix bug, when set selectedSegmentIndex, the title color  mistake

### DIFF
--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -522,6 +522,9 @@
     self.userInteractionEnabled = NO;
     
     _selectedSegmentIndex = segment;
+    
+    [self willSelectedButton:self.buttons[_selectedSegmentIndex]];
+    
     _transitioning = YES;
     
     void (^animations)() = ^void(){
@@ -531,6 +534,7 @@
     void (^completion)(BOOL finished) = ^void(BOOL finished){
         self.userInteractionEnabled = YES;
         _transitioning = NO;
+        [self didSelectButton:self.buttons[_selectedSegmentIndex]];
     };
     
     if (animated) {


### PR DESCRIPTION
When the segment title is chinese, and i set selectedSegmentIndex, but the title color not selected color.
![1](https://cloud.githubusercontent.com/assets/2653709/9299399/13d0ac5a-44ee-11e5-8b41-6770342fc50e.jpg)
