### PR TITLE
fixed issue with tagged strings

### DIFF
--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -429,10 +429,10 @@
     
     id firstItem = [items firstObject];
     
-    NSPredicate *classPredicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@", [firstItem class]];
-    NSAssert([items filteredArrayUsingPredicate:classPredicate].count == items.count, @"Cannot include different objects in the array. Please make sure to either pass an array of NSString or UIImage objects.");
-    
     _imageMode = [firstItem isKindOfClass:[UIImage class]];
+    
+    NSPredicate *classPredicate = [NSPredicate predicateWithFormat:@"self isKindOfClass: %@", _imageMode ? [UIImage class] : [NSString class]];
+    NSAssert([items filteredArrayUsingPredicate:classPredicate].count == items.count, @"Cannot include different objects in the array. Please make sure to either pass an array of NSString or UIImage objects.");
     
     _items = [NSArray arrayWithArray:items];
     


### PR DESCRIPTION
NSString *str1 = [@"abcdefghi".mutableCopy copy];
NSString *str2 = [@"abcdefghij".mutableCopy copy];

NSLog(@"%@", [str1 class]); // NSTaggedPointerString
NSLog(@"%@", [str2 class]); // __NSCFString

NSArray *array = @[str1, str2];

NSLog(@"%d", [items filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self isKindOfClass: %@", [str1 class]]].count); // 1

https://www.mikeash.com/pyblog/friday-qa-2015-07-31-tagged-pointer-strings.html