### PR TITLE
Better interaction handling

### DIFF
--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -20,7 +20,6 @@
 
 @property (nonatomic, assign) CGPoint scrollOffset;
 
-@property (nonatomic, getter = isTransitioning) BOOL transitioning;
 @property (nonatomic, getter = isImageMode) BOOL imageMode; // Default NO
 
 @end
@@ -535,25 +534,17 @@
 
 - (void)setSelectedSegmentIndex:(NSInteger)segment animated:(BOOL)animated
 {
-    if (self.numberOfSegments == 0 || self.selectedSegmentIndex == segment || self.isTransitioning) {
+    if (self.numberOfSegments == 0 || self.selectedSegmentIndex == segment) {
         return;
     }
     
     [self unselectAllButtons];
     [self.buttons[segment] setSelected:YES];
     
-    self.userInteractionEnabled = NO;
-    
     _selectedSegmentIndex = segment;
-    _transitioning = YES;
     
     void (^animations)() = ^void(){
         self.selectionIndicator.frame = [self selectionIndicatorRect];
-    };
-    
-    void (^completion)(BOOL finished) = ^void(BOOL finished){
-        self.userInteractionEnabled = YES;
-        _transitioning = NO;
     };
     
     if (animated) {
@@ -567,11 +558,10 @@
               initialSpringVelocity:velocity
                             options:UIViewAnimationOptionBeginFromCurrentState|UIViewAnimationOptionCurveEaseInOut
                          animations:animations
-                         completion:completion];
+                         completion:NULL];
     }
     else {
         animations();
-        completion(NO);
     }
 }
 
@@ -911,7 +901,7 @@
 {
     UIButton *button = (UIButton *)sender;
     
-    if (self.selectedSegmentIndex != button.tag && !self.isTransitioning) {
+    if (self.selectedSegmentIndex != button.tag) {
         [self setSelectedSegmentIndex:button.tag animated:YES];
         [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
@@ -941,10 +931,6 @@
 
 - (void)removeAllSegments
 {
-    if (self.isTransitioning) {
-        return;
-    }
-    
     // Removes all the buttons
     [[self buttons] makeObjectsPerformSelector:@selector(removeFromSuperview)];
     

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -539,7 +539,11 @@
     }
     
     [self unselectAllButtons];
-    [self.buttons[segment] setSelected:YES];
+    [self enableAllButtonsInteraction:YES];
+    
+    UIButton *targetButton = self.buttons[segment];
+    targetButton.selected = YES;
+    targetButton.userInteractionEnabled = NO;
     
     _selectedSegmentIndex = segment;
     


### PR DESCRIPTION
Removes the 'transitioning' flag and doesn't disable interaction while the selection indicator is being animated anymore.

This was causing not to receive touch input while the transition was being performed, causing to forward the touch event to any subview that was below the segmented control, involuntarily.
It is now possible to select multiple segments on the row, very quickly, and the view will respond perfectly re-adjusting to the latest selected segmented correctly.