### PR TITLE
Move isImageMode property to public header file

### DIFF
--- a/Source/DZNSegmentedControl.h
+++ b/Source/DZNSegmentedControl.h
@@ -60,6 +60,8 @@ enum {
 @property (nonatomic) BOOL adjustsButtonTopInset;
 /** YES if the selected segment is user interaction disabled. NO if touching the segment button should still forward the actions to its targets without animating the selection indicator. Default is YES. */
 @property (nonatomic) BOOL disableSelectedSegment;
+/** YES if the image mode is enable. Default is NO. */
+@property (nonatomic, getter = isImageMode) BOOL imageMode;
 
 /**
  Initializes and returns a segmented control with segments having the given titles or images.

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -20,8 +20,6 @@
 
 @property (nonatomic, assign) CGPoint scrollOffset;
 
-@property (nonatomic, getter = isImageMode) BOOL imageMode; // Default NO
-
 @end
 
 @implementation DZNSegmentedControl


### PR DESCRIPTION
Should we move `isImageMode` property to header file so that we could make this property to `YES` and do more further configurations?