### PR TITLE
Auto indicator width for observed scroll view.

### DIFF
--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -496,8 +496,8 @@
 
 - (void)setScrollOffset:(CGPoint)scrollOffset contentSize:(CGSize)contentSize
 {
-    self.autoAdjustSelectionIndicatorWidth = NO;
-    self.bouncySelectionIndicator = NO;
+//    self.autoAdjustSelectionIndicatorWidth = NO;
+//    self.bouncySelectionIndicator = NO;
     
     CGFloat offset = 0.0;
     
@@ -517,7 +517,7 @@
     CGFloat buttonWidth = roundf(self.width/self.numberOfSegments);
     
     CGRect indicatorRect = self.selectionIndicator.frame;
-    indicatorRect.origin.x = (buttonWidth * offset);
+    indicatorRect.origin.x = (buttonWidth * offset) + (buttonWidth - CGRectGetWidth(indicatorRect)) / 2;
     self.selectionIndicator.frame = indicatorRect;
     
     NSUInteger index = (NSUInteger)offset;

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -496,9 +496,6 @@
 
 - (void)setScrollOffset:(CGPoint)scrollOffset contentSize:(CGSize)contentSize
 {
-//    self.autoAdjustSelectionIndicatorWidth = NO;
-//    self.bouncySelectionIndicator = NO;
-    
     CGFloat offset = 0.0;
     
     // Horizontal scroll


### PR DESCRIPTION
Segmented control set its indicator's frame appropriately when observed scroll view's content offset changing and autoAdjustSelectionIndicatorWidth is true.

Used:
#83 

Now:

![simulator screen shot 2017 2 15 18 13 41](https://cloud.githubusercontent.com/assets/12030413/22969986/68a80922-f3ab-11e6-8e30-73dc6b14f423.png)

![simulator screen shot 2017 2 15 18 13 55](https://cloud.githubusercontent.com/assets/12030413/22969985/68a80b34-f3ab-11e6-9903-97c01134f5ca.png)
